### PR TITLE
add support for base64 wallet logos

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,5 @@
+export function isBase64Image(str: string | undefined): boolean {
+    if (!str) return false
+    const regex = /^data:image\/(jpeg|png|gif|bmp|svg\+xml);base64,([^\s]*)$/
+    return regex.test(str)
+}

--- a/src/ui/components/ListItem.svelte
+++ b/src/ui/components/ListItem.svelte
@@ -14,6 +14,8 @@
             <Icon name={leadingIcon} />
         {/if}
 
+        <slot name="logo" />
+
         <div>
             <span>{label}</span>
             {#if trailingIcon}

--- a/src/ui/components/icons/Wallet.svelte
+++ b/src/ui/components/icons/Wallet.svelte
@@ -1,0 +1,13 @@
+<svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    ><path d="M20 12V8H6a2 2 0 0 1-2-2c0-1.1.9-2 2-2h12v4" /><path
+        d="M4 6v12c0 1.1.9 2 2 2h14v-4"
+    /><path d="M18 12a2 2 0 0 0-2 2c0 1.1.9 2 2 2h4v-4h-4z" /></svg
+>

--- a/src/ui/components/icons/index.ts
+++ b/src/ui/components/icons/index.ts
@@ -6,6 +6,7 @@ import Wharf from './Wharf.svelte'
 import Login from './LogIn.svelte'
 import ChevronRight from './ChevronRight.svelte'
 import ChevronLeft from './ChevronLeft.svelte'
+import Wallet from './Wallet.svelte'
 
 export default {
     copy: Copy,
@@ -16,4 +17,5 @@ export default {
     login: Login,
     'chevron-right': ChevronRight,
     'chevron-left': ChevronLeft,
+    wallet: Wallet,
 }

--- a/src/ui/login/Wallet.svelte
+++ b/src/ui/login/Wallet.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
     import {createEventDispatcher} from 'svelte'
     import {UserInterfaceWalletPlugin} from '@wharfkit/session'
-
+    import Icon from '../components/Icon.svelte'
     import List from '../components/List.svelte'
     import ListItem from '../components/ListItem.svelte'
-    import Loading from '../components/Loading.svelte'
+    import {isBase64Image} from '../../lib/utils'
 
     export let wallets: UserInterfaceWalletPlugin[]
 
@@ -12,18 +12,37 @@
         select: number
         cancel: void
     }>()
+
+    const hasValidLogo = ({metadata: {logo, name}}: UserInterfaceWalletPlugin) => {
+        if (isBase64Image(logo)) {
+            return true
+        } else {
+            console.warn(`${name} logo is not a valid base64 image`)
+            return false
+        }
+    }
 </script>
 
-<div>
-    <!-- <Loading loading /> -->
-    {#if wallets}
-        <List>
-            {#each wallets as wallet, index}
-                <ListItem label={wallet.metadata.name} onClick={() => dispatch('select', index)} />
-            {/each}
-        </List>
-    {/if}
-</div>
+{#if wallets}
+    <List>
+        {#each wallets as wallet, index}
+            <ListItem label={wallet.metadata.name} onClick={() => dispatch('select', index)}>
+                <div class="logo" slot="logo">
+                    {#if hasValidLogo(wallet)}
+                        <img
+                            src={wallet.metadata.logo}
+                            alt={wallet.metadata.name}
+                            width="32"
+                            height="32"
+                        />
+                    {:else}
+                        <Icon name="wallet" />
+                    {/if}
+                </div>
+            </ListItem>
+        {/each}
+    </List>
+{/if}
 
 <style lang="scss">
     ul {
@@ -37,5 +56,10 @@
     li {
         flex: 1;
         display: flex;
+    }
+
+    .logo {
+        display: grid;
+        place-content: center;
     }
 </style>


### PR DESCRIPTION
Renders the logo of the wallet plugin if it has a valid base64 image. Fallback to a wallet icon.

![image](https://user-images.githubusercontent.com/7519573/230484898-474f239e-88ef-41b8-8787-f673666a89ea.png)
