### PR TITLE
Fix css errors by removing svg size tokens

### DIFF
--- a/src/ui/components/icons/Check.svelte
+++ b/src/ui/components/icons/Check.svelte
@@ -1,11 +1,7 @@
-<script lang="ts">
-    export let size: string = 'var(--space-l)'
-</script>
-
 <svg
     xmlns="http://www.w3.org/2000/svg"
-    width={size}
-    height={size}
+    width="24"
+    height="24"
     viewBox="0 0 24 24"
     fill="none"
     stroke="currentColor"

--- a/src/ui/components/icons/ChevronLeft.svelte
+++ b/src/ui/components/icons/ChevronLeft.svelte
@@ -1,11 +1,7 @@
-<script lang="ts">
-    export let size: string = 'var(--space-l)'
-</script>
-
 <svg
     xmlns="http://www.w3.org/2000/svg"
-    width={size}
-    height={size}
+    width="24"
+    height="24"
     viewBox="0 0 24 24"
     fill="none"
     stroke="currentColor"

--- a/src/ui/components/icons/ChevronRight.svelte
+++ b/src/ui/components/icons/ChevronRight.svelte
@@ -1,11 +1,7 @@
-<script lang="ts">
-    export let size: string = 'var(--space-l)'
-</script>
-
 <svg
     xmlns="http://www.w3.org/2000/svg"
-    width={size}
-    height={size}
+    width="24"
+    height="24"
     viewBox="0 0 24 24"
     fill="none"
     stroke="currentColor"

--- a/src/ui/components/icons/CloseIcon.svelte
+++ b/src/ui/components/icons/CloseIcon.svelte
@@ -1,11 +1,7 @@
-<script lang="ts">
-    export let size: string = 'var(--space-l)'
-</script>
-
 <svg
     xmlns="http://www.w3.org/2000/svg"
-    width={size}
-    height={size}
+    width="24"
+    height="24"
     viewBox="0 0 24 24"
     fill="none"
     stroke="currentColor"

--- a/src/ui/components/icons/Copy.svelte
+++ b/src/ui/components/icons/Copy.svelte
@@ -1,11 +1,7 @@
-<script lang="ts">
-    export let size: string = 'var(--space-l)'
-</script>
-
 <svg
     xmlns="http://www.w3.org/2000/svg"
-    width={size}
-    height={size}
+    width="24"
+    height="24"
     viewBox="0 0 24 24"
     fill="none"
     stroke="currentColor"

--- a/src/ui/components/icons/Expand.svelte
+++ b/src/ui/components/icons/Expand.svelte
@@ -1,11 +1,7 @@
-<script lang="ts">
-    export let size: string = 'var(--space-l)'
-</script>
-
 <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="100%"
-    height="100%"
+    width="24"
+    height="24"
     viewBox="0 0 24 24"
     fill="none"
     stroke="currentColor"

--- a/src/ui/components/icons/FileCode.svelte
+++ b/src/ui/components/icons/FileCode.svelte
@@ -1,11 +1,7 @@
-<script lang="ts">
-    export let size: string = 'var(--space-l)'
-</script>
-
 <svg
     xmlns="http://www.w3.org/2000/svg"
-    width={size}
-    height={size}
+    width="24"
+    height="24"
     viewBox="0 0 24 24"
     fill="none"
     stroke="currentColor"

--- a/src/ui/components/icons/LogIn.svelte
+++ b/src/ui/components/icons/LogIn.svelte
@@ -1,11 +1,7 @@
-<script lang="ts">
-    export let size: string = 'var(--space-l)'
-</script>
-
 <svg
     xmlns="http://www.w3.org/2000/svg"
-    width={size}
-    height={size}
+    width="24"
+    height="24"
     viewBox="0 0 24 24"
     fill="none"
     stroke="currentColor"


### PR DESCRIPTION
inlined custom properties threw errors and were removed. 
icon svg sizing is being handled by a parent div