### PR TITLE
fix list item columns to account for no-icon lists

### DIFF
--- a/src/ui/components/ListItem.svelte
+++ b/src/ui/components/ListItem.svelte
@@ -6,16 +6,18 @@
     export let onClick
     export let leadingIcon: ComponentProps<Icon>['name'] | undefined = undefined
     export let trailingIcon: ComponentProps<Icon>['name'] | undefined = 'chevron-right'
+    export let logo: string | undefined = undefined
 </script>
 
 <li>
     <button on:click={onClick}>
-        {#if leadingIcon}
+        {#if logo}
+            <img class="logo leading" src={logo} alt={''} width="32" height="32" />
+        {:else if leadingIcon}
             <div class="icon leading">
                 <Icon name={leadingIcon} />
             </div>
         {/if}
-        <slot name="logo" />
 
         <span>{label}</span>
 
@@ -38,8 +40,7 @@
 
     li button {
         flex: 1;
-        display: grid;
-        grid-template-columns: var(--space-xl) 1fr auto;
+        display: flex;
         align-items: center;
         gap: var(--space-s);
         cursor: pointer;
@@ -49,6 +50,12 @@
         font-size: var(--fs-1);
         font-weight: 500;
         padding-block: var(--space-s);
+    }
+
+    :is(.icon, .logo).leading {
+        flex-basis: var(--space-xl);
+        display: grid;
+        place-content: center;
     }
 
     .icon.trailing {
@@ -64,6 +71,7 @@
     }
 
     span {
+        flex: 1;
         text-align: start;
         overflow: hidden;
         text-overflow: ellipsis;

--- a/src/ui/login/Wallet.svelte
+++ b/src/ui/login/Wallet.svelte
@@ -29,20 +29,12 @@
         <BodyTitle>{title}</BodyTitle>
         <List>
             {#each wallets as wallet, index}
-                <ListItem label={wallet.metadata.name} onClick={() => dispatch('select', index)}>
-                    <div class="logo" slot="logo">
-                        {#if hasValidLogo(wallet)}
-                            <img
-                                src={wallet.metadata.logo}
-                                alt={wallet.metadata.name}
-                                width="32"
-                                height="32"
-                            />
-                        {:else}
-                            <Icon name="wallet" />
-                        {/if}
-                    </div>
-                </ListItem>
+                <ListItem
+                    label={wallet.metadata.name}
+                    onClick={() => dispatch('select', index)}
+                    leadingIcon="wallet"
+                    logo={hasValidLogo(wallet) ? wallet.metadata.logo : undefined}
+                />
             {/each}
         </List>
     </section>


### PR DESCRIPTION
Moved from a grid layout to a flex layout. This way the label won't populate the icon/logo column if there's no icon/logo passed to the list item component. 

Fixes #58